### PR TITLE
Changed API_News_Call, to API_Wiki_Call and configured the api call

### DIFF
--- a/API_News_Call.py
+++ b/API_News_Call.py
@@ -1,1 +1,0 @@
-# Calls Library of Congress's Chronicaling America to return a news paper from the given date. 

--- a/API_Wiki_Call.py
+++ b/API_Wiki_Call.py
@@ -1,0 +1,17 @@
+
+""""Using Wikipedia's API to return the events that happened on the day chosen by the user."""
+
+import requests
+from pprint import pprint
+
+# user_date is currently hardcoded, this will take a variable later that is passed to it from ui.py.
+user_date = 'October 9'
+
+query = {'action':'opensearch', 'namespace':0, 'search': user_date, 'limit':1}
+
+
+url ='https://en.wikipedia.org/w/api.php'
+
+data = requests.get(url, params = query).json()
+
+pprint(data[3])


### PR DESCRIPTION
Configured the wiki api, this will call retrieve everything that happened on that day.  Year is not important, and there is no need for a key.