### PR TITLE
removed primary year from search query prams.

### DIFF
--- a/API_Movie_Call.py
+++ b/API_Movie_Call.py
@@ -42,11 +42,13 @@ def set_api_discover_params(year, month, day, key) -> dict:
     'sort_by':'release_date.desc', # Sorts the results of the API Call.
     'include_adult':'false',
     'include_video':'false',
-    'page':'1', # Page represents what page of the results will be looked at.
-    'primary_release_year':year, 
+    'page':'1', # Page represents what page of the results will be looked at. 
     'primary_release_date.lte':f'{year}-{month}-{day}',
     'vote_average.gte':'3', 
-    'with_original_language':'en'}
+    'with_original_language':'en',
+    'with_runtime.gte' : 60,
+    'without_genres': 10770 # 10770 is TV Movie releases.
+    }
 
     return query
 


### PR DESCRIPTION
Primary_release_date was doing the same as primary_release_year and having both calls was affecting the returns so I removed the Primary year to get better results. also added a few more params to curate better results.